### PR TITLE
add break to setup command switch case

### DIFF
--- a/src/handlers/chatInputCommand.ts
+++ b/src/handlers/chatInputCommand.ts
@@ -71,6 +71,7 @@ export async function handleChatInputCommand(
           ephemeral: true,
         });
       }
+      break;
     }
     case 'roles': {
       return handleRolesCommand(client, interaction);


### PR DESCRIPTION
missing break; causes an error when running setup command due to dropping to next case.